### PR TITLE
Prevent excessive writes of .vscode/settings.json (fix issue #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+v1.0.1 - fix(app): prevent excessive writing of .vscode/settings.json
+
 v1.0.0 - fix(app): support multi-root workspaces
 
 v0.1.4 - fix(app): fix extension initialization workflow

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "explorer-excluded-files",
 	"displayName": "explorer-excluded-files",
 	"description": "Exclude files from the Visual Studio Code explorer",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"publisher": "sadesyllas",
 	"engines": {
 		"vscode": "^1.15.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,7 +167,7 @@ function clearWorkspaceConfiguration(workspaceFolder: vscode.WorkspaceFolder, do
 	}
 
 	if (workspaceConfiguration[explorerExcludedFilesShowKey]) {
-		if (!configurationsAreIdentical(workspaceConfiguration, JSON.parse(workspaceConfigurationText))) {
+		if (!dontWrite && !configurationsAreIdentical(workspaceConfiguration, JSON.parse(workspaceConfigurationText))) {
 			writeWorkspaceConfiguration(workspaceFolder, workspaceConfiguration);
 		}
 
@@ -189,7 +189,7 @@ function clearWorkspaceConfiguration(workspaceFolder: vscode.WorkspaceFolder, do
 			? fs.readdirSync(workspaceVSCodeDirectoryPath)
 			: [];
 
-		if (workspaceVSCodeDirectoryEntries.length === 1 && workspaceVSCodeDirectoryEntries[0] === 'settings.json') {
+		if (!dontWrite && workspaceVSCodeDirectoryEntries.length === 1 && workspaceVSCodeDirectoryEntries[0] === 'settings.json') {
 			fs.unlinkSync(path.join(workspaceVSCodeDirectoryPath, 'settings.json'));
 			fs.rmdirSync(workspaceVSCodeDirectoryPath);
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,8 @@ const explorerExcludedFilesPatternsKey = 'explorerExcludedFiles.patterns';
 const explorerExcludedFilesShowKey = 'explorerExcludedFiles.show';
 const cycleDelay = 2500;
 
+let shuttingDown = false;
+
 function getCodeName() {
 	return `Code${/insider/i.test(vscode.version) ? ' - Insiders' : ''}`;
 }
@@ -136,15 +138,20 @@ function writeWorkspaceConfiguration(workspaceFolder: vscode.WorkspaceFolder, wo
 	writeUTF8(path.join(workspaceVSCodeDirectoryPath, 'settings.json'), JSONStringify(workspaceConfiguration));
 }
 
-function clearWorkspaceConfiguration(workspaceFolder: vscode.WorkspaceFolder) {
+function clearWorkspaceConfiguration(workspaceFolder: vscode.WorkspaceFolder, dontWrite = false) {
+	const emptyConfiguration = {
+		text: '{}',
+		json: {},
+	};
+
 	if (!workspaceFolder || !workspaceFolder.uri) {
-		return;
+		return emptyConfiguration;
 	}
 
 	const rootPath = workspaceFolder.uri.fsPath;
 
 	if (!rootPath) {
-		return;
+		return emptyConfiguration;
 	}
 
 	const { text: workspaceConfigurationText, json: workspaceConfiguration } = readWorkspaceConfiguration(workspaceFolder);
@@ -164,15 +171,19 @@ function clearWorkspaceConfiguration(workspaceFolder: vscode.WorkspaceFolder) {
 			writeWorkspaceConfiguration(workspaceFolder, workspaceConfiguration);
 		}
 
-		return;
+		return {
+			json: workspaceConfiguration,
+			text: workspaceConfigurationText
+		};
 	}
 
 	const workspaceConfigurationKeys = Object.keys(workspaceConfiguration);
 
 	if (!workspaceConfigurationKeys.length ||
-			(workspaceConfigurationKeys.length === 1 &&
-			 typeof(workspaceConfiguration[explorerExcludedFilesShowKey]) !== 'undefined' &&
-			 !workspaceConfiguration[explorerExcludedFilesShowKey])) {
+		(workspaceConfigurationKeys.length === 1 &&
+			typeof (workspaceConfiguration[explorerExcludedFilesShowKey]) !== 'undefined' &&
+			!workspaceConfiguration[explorerExcludedFilesShowKey])
+	) {
 		const workspaceVSCodeDirectoryPath = path.join(rootPath, '.vscode');
 		const workspaceVSCodeDirectoryEntries = fs.existsSync(workspaceVSCodeDirectoryPath)
 			? fs.readdirSync(workspaceVSCodeDirectoryPath)
@@ -183,64 +194,28 @@ function clearWorkspaceConfiguration(workspaceFolder: vscode.WorkspaceFolder) {
 			fs.rmdirSync(workspaceVSCodeDirectoryPath);
 		}
 
-		return;
+		return {
+			json: workspaceConfiguration,
+			text: workspaceConfigurationText
+		};
 	}
 
-	if (!configurationsAreIdentical(workspaceConfiguration, JSON.parse(workspaceConfigurationText))) {
+	if (!dontWrite && !configurationsAreIdentical(workspaceConfiguration, JSON.parse(workspaceConfigurationText))) {
 		writeWorkspaceConfiguration(workspaceFolder, workspaceConfiguration);
 	}
+
+	return {
+		json: workspaceConfiguration,
+		text: workspaceConfigurationText
+	};
 }
 
 function clearWorkspaceConfigurations() {
 	(vscode.workspace.workspaceFolders || []).forEach(workspaceFolder => clearWorkspaceConfiguration(workspaceFolder));
 }
 
-function patchWorkspaceConfiguration(workspaceFolder: vscode.WorkspaceFolder, patterns: string[]) {
-	patterns = patterns || [];
-
-	if (!workspaceFolder || !workspaceFolder.uri) {
-		return;
-	}
-
-	const rootPath = workspaceFolder.uri.fsPath;
-
-	if (!rootPath) {
-		return;
-	}
-
-	const { text: workspaceConfigurationText, json: workspaceConfiguration } = readWorkspaceConfiguration(workspaceFolder);
-
-	if (workspaceConfiguration[explorerExcludedFilesShowKey]) {
-		return;
-	}
-
-	if (!workspaceConfiguration[filesExcludeKey]) {
-		workspaceConfiguration[filesExcludeKey] = {};
-	}
-
-	patterns.forEach(pattern => {
-		if (/^file:\/\//i.test(pattern)) {
-			const filePath = path.join(rootPath, pattern.replace(/^file:\/\//i, ''));
-			if (fs.existsSync(filePath)) {
-				readUTF8(filePath).split(/\r?\n/g).map(p => p.trim()).filter(p => !/^\s*$/.test(p) && p[0] !== '#')
-					.map(p => p.replace(/^\/+/, '')).filter(p => typeof(workspaceConfiguration[filesExcludeKey][p]) === 'undefined')
-					.forEach(p => workspaceConfiguration[filesExcludeKey][p] = 'explorerExcludedFiles');
-			}
-			return;
-		}
-
-		if (typeof(workspaceConfiguration[filesExcludeKey][pattern]) === 'undefined') {
-			workspaceConfiguration[filesExcludeKey][pattern] = 'explorerExcludedFiles';
-		}
-	});
-
-	if (!configurationsAreIdentical(workspaceConfiguration, JSON.parse(workspaceConfigurationText))) {
-		writeWorkspaceConfiguration(workspaceFolder, workspaceConfiguration);
-	}
-}
-
 function patchUserConfiguration(workspaceFolder: vscode.WorkspaceFolder, promiseResolver: (value?: any) => void) {
-	if (!workspaceFolder || !workspaceFolder.uri) {
+	if (!workspaceFolder || !workspaceFolder.uri || shuttingDown) {
 		return;
 	}
 
@@ -259,14 +234,38 @@ function patchUserConfiguration(workspaceFolder: vscode.WorkspaceFolder, promise
 		writeUserConfiguration(userConfiguration);
 	}
 
-	clearWorkspaceConfiguration(workspaceFolder);
+	const { json: workspaceConfiguration, text: workspaceConfigurationText } = clearWorkspaceConfiguration(workspaceFolder, true);
 
 	if (!rootPath) {
 		promiseResolver();
 		return;
 	}
 
-	patchWorkspaceConfiguration(workspaceFolder, explorerExcludedFilesPatterns);
+	if (!workspaceConfiguration[explorerExcludedFilesShowKey]) {
+		if (!workspaceConfiguration[filesExcludeKey]) {
+			workspaceConfiguration[filesExcludeKey] = {};
+		}
+
+		explorerExcludedFilesPatterns.forEach(pattern => {
+			if (/^file:\/\//i.test(pattern)) {
+				const filePath = path.join(rootPath, pattern.replace(/^file:\/\//i, ''));
+				if (fs.existsSync(filePath)) {
+					readUTF8(filePath).split(/\r?\n/g).map(p => p.trim()).filter(p => !/^\s*$/.test(p) && p[0] !== '#')
+						.map(p => p.replace(/^\/+/, '')).filter(p => typeof (workspaceConfiguration[filesExcludeKey][p]) === 'undefined')
+						.forEach(p => workspaceConfiguration[filesExcludeKey][p] = 'explorerExcludedFiles');
+				}
+				return;
+			}
+
+			if (typeof (workspaceConfiguration[filesExcludeKey][pattern]) === 'undefined') {
+				workspaceConfiguration[filesExcludeKey][pattern] = 'explorerExcludedFiles';
+			}
+		});
+	}
+
+	if (!configurationsAreIdentical(workspaceConfiguration, JSON.parse(workspaceConfigurationText))) {
+		writeWorkspaceConfiguration(workspaceFolder, workspaceConfiguration);
+	}
 
 	promiseResolver();
 }
@@ -297,7 +296,7 @@ function toggleExplorerExcludedFiles(show: boolean) {
 }
 
 function onDidChangeWorkspaceFolders(event: vscode.WorkspaceFoldersChangeEvent) {
-	(event.removed || []).forEach(clearWorkspaceConfiguration);
+	(event.removed || []).forEach(workspaceFolder => clearWorkspaceConfiguration(workspaceFolder));
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -317,5 +316,6 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate(context: vscode.ExtensionContext) {
+	shuttingDown = true;
 	clearWorkspaceConfigurations();
 }


### PR DESCRIPTION
The settings file currently is re-written twice every few seconds - for every folder in our workspace. This per se is excessive. But it's particularly bad if that folder is on a folder which is being synced to some cloud storage. It triggers sync activity for several files every few seconds. In one of my cases Dropbox basically was constantly busy syncing those files, as I have half a dozen or more folders in my workspace.

This change does still the same cleanup/patch routine before. But intermediate results are not written to and read from disc, but passed from one handler to the other in memory. Previously cleanup would remove the extension's entries from settings.json, write that change, and patch would add them back in if nothing has changed. But despite there being no change two writes were required.